### PR TITLE
fixed window download

### DIFF
--- a/geohabnet/R/ccri_helper.R
+++ b/geohabnet/R/ccri_helper.R
@@ -85,7 +85,7 @@ library(yaml)
 
 .download <- function(uri) {
   f <- paste(tempfile(), ".tif", sep = "")
-  stopifnot("dowload failed " = utils::download.file(uri, destfile = f, method = "auto") == 0)
+  stopifnot("dowload failed " = utils::download.file(uri, destfile = f, method = "auto", mode = "wb") == 0)
   return(f)
 }
 


### PR DESCRIPTION
There was an issue in writing file after download in windows. Windows requires binary mode to be specified explicitly when writing file thus was creating improper spatRaster object. This was preventing analysis and operations in windows.